### PR TITLE
New: get email from authn response subject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ target/
 .ipynb_checkpoints
 
 .idea
+*.swp

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -199,7 +199,7 @@ def acs(r):
                     settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('last_name', 'LastName')
                 ][0]
             except (KeyError, IndexError) as exc:
-                logger.debug('could not get user info attributes from response %s exc= %s' % (authn_response, exc))
+                logger.error('could not get user info attributes from response exc= %s' % exc)
             if user_email and user_first_name and user_last_name:
                 target_user = _create_new_user(user_name, user_email, user_first_name, user_last_name)
                 if settings.SAML2_AUTH.get('TRIGGER', {}).get('CREATE_USER', None):

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -178,12 +178,12 @@ def acs(r):
     if settings.SAML2_AUTH.get('GET_USERNAME_FROM_SUBJECT', False):
         try:
             user_name = authn_response.get_subject().text
-        except AttributeError:
-            logger.error('could not get subject value from authn response %s' % authn_response)
+        except (AttributeError, AssertionError) as exc:
+            logger.error('could not get subject value from authn response exc=%s' % exc)
     else:
         user_name = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('username', 'UserName')][0]
     if user_name is None:
-        raise ValueError('could not get user email from authn response %s' % authn_response)
+        raise ValueError('could not get user email from authn response')
 
     try:
         user_email = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('email', 'Email')][0]


### PR DESCRIPTION
```
Subject NameID: <ns0:NameID xmlns:ns0="urn:oasis:names:tc:SAML:2.0:assertion" Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">john.doe@db.com</ns0:NameID>
[DEBUG 2019-08-22 08:51:33,901 saml2.response get_identity 684: MainProcess] Assertion contains no attribute statements
[DEBUG 2019-08-22 08:51:33,901 saml2.response parse_assertion 1028: MainProcess] --- AVA: {}
[INFO 2019-08-22 08:51:33,901 saml2.client_base parse_authn_request_response 731: MainProcess] --- ADDED person info ----
[DEBUG 2019-08-22 08:51:33,902 saml2.response get_identity 684: MainProcess] Assertion contains no attribute statements
[ERROR 2019-08-22 08:51:33,902 django.request handle_uncaught_exception 135: MainProcess] Internal Server Error: /api/saml2_auth/acs/
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/dist-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/dist-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.6/dist-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/django_saml2_auth/views.py", line 174, in acs
    user_email = user_identity[settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('email', 'Email')][0]
KeyError: 'namedid-format:emailAddress'
``` 
this is an example of response sent from DWS IdP.

Related to: https://github.com/feedstock/feedstock_backend/pull/192