### PR TITLE
bump pysaml2

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -191,6 +191,9 @@ def acs(r):
     if user_identity is None:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
+    logger.info(f'user identity {user_identity}')
+    logger.info(f'settings {settings.SAML2_AUTH}')
+
     user_name = get_identity_attr(
         user_identity,
         settings.SAML2_AUTH.get('ATTRIBUTES_MAP', {}).get('username', 'UserName')

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -198,7 +198,9 @@ def acs(r):
     if user_name is None:
         logger.info('could not get username from attributes, trying subject')
         subj = authn_response.get_subject()
-        if subj and subj.c_tag == 'NameID' and subj.format and 'emailAddress' in subj.format:
+        if subj and subj.c_tag == 'NameID':
+            if subj.format and 'emailAddress' not in subj.format:
+                logger.warning(f'emailAddress is not found in subject format. the format is: {subj.format}')
             user_name = subj.text
         else:
             logger.info('could not get user name from subject')

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -191,7 +191,7 @@ def acs(r):
     if user_identity is None:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
-    logger.info(f'user identity: {user_identity}')
+    logger.debug(f'user identity: {user_identity}')
     logger.debug(f'settings.SAML2_AUTH: {settings.SAML2_AUTH}')
 
     user_name = get_identity_attr(

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -191,8 +191,8 @@ def acs(r):
     if user_identity is None:
         return HttpResponseRedirect(get_reverse([denied, 'denied', 'django_saml2_auth:denied']))
 
-    logger.info(f'user identity {user_identity}')
-    logger.info(f'settings {settings.SAML2_AUTH}')
+    logger.info(f'user identity: {user_identity}')
+    logger.debug(f'settings.SAML2_AUTH: {settings.SAML2_AUTH}')
 
     user_name = get_identity_attr(
         user_identity,

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -199,6 +199,8 @@ def acs(r):
         logger.info('could not get username from attributes, trying subject')
         subj = authn_response.get_subject()
         if subj and subj.c_tag == 'NameID':
+            if not subj.format:
+                logger.warning('no subject format')
             if subj.format and 'emailAddress' not in subj.format:
                 logger.warning(f'emailAddress is not found in subject format. the format is: {subj.format}')
             user_name = subj.text

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='django_saml2_auth',
 
-    version='2.2.1',
+    version='2.2.2',
 
     description='Django SAML2 Authentication Made Easy. Easily integrate with SAML2 SSO identity providers like Okta',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
 
     packages=find_packages(),
 
-    install_requires=['pysaml2>=4.5.0',
+    install_requires=['pysaml2>=6.5.1',
                       'djangorestframework-jwt',
                       'django-rest-auth', ],
     include_package_data=True,


### PR DESCRIPTION
Estimated here: https://github.com/feedstock/feedstock_backend/pull/462
```
-----
JUPITER UAT (no change needed)

"[INFO 2020-11-02 15:02:51,381 saml2.response get_subject 782: MainProcess] Subject NameID: <ns0:NameID xmlns:ns0=\"urn:oasis:names:tc:SAML:2.0:assertion\" Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">Malcolm.Goodier@jupiteram.com</ns0:NameID>\n"
"[INFO 2020-11-02 15:02:51,384 saml2.client_base parse_authn_request_response 732: MainProcess] --- ADDED person info ----\n",
"[INFO 2020-11-02 15:02:51,407 axes.watch_login log_user_logged_in 137: MainProcess] AXES: Successful login by {user: 'malcolm.goodier@jupiteram.com', ip: '85.115.54.201', user-agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.111 Safari/537.36 Edg/86.0.622.51', path: '/api/saml2_auth/acs/'}.\n"

app@feedstock-backend-6cf54b45d6-tb29w:~$ feedstock-env-bootstrap env | grep SAML
FDSK_SAML_WANT_RESPONSE_SIGNED=1
FDSK_SAML_ATTRIBUTES_MAP={"username":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"}  <-- this matches in identity and we don't check subject

-----
DWS UAT (probably needs update)

"[INFO 2020-12-04 10:02:21,520 saml2.response get_subject 782: MainProcess] Subject NameID: <ns0:NameID xmlns:ns0=\"urn:oasis:names:tc:SAML:2.0:assertion\" Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">shaoni.ghosh@db.com</ns0:NameID>\n",
"[INFO 2020-12-04 10:02:21,523 saml2.client_base parse_authn_request_response 732: MainProcess] --- ADDED person info ----\n"
"[INFO 2020-12-04 10:02:21,523 django_saml2_auth.views acs 199: MainProcess] could not get username from attributes, trying subject\n"
"[INFO 2020-12-04 10:02:21,523 saml2.response get_subject 782: MainProcess] Subject NameID: <ns0:NameID xmlns:ns0=\"urn:oasis:names:tc:SAML:2.0:assertion\" Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">shaoni.ghosh@db.com</ns0:NameID>\n"
 "[INFO 2020-12-04 10:02:21,587 axes.watch_login log_user_logged_in 137: MainProcess] AXES: Successful login by {user: 'shaoni.ghosh@db.com', ip: '160.83.97.85', user-agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36', path: '/api/saml2_auth/acs/'}.\n"

-----
Well UAT  (no change needed)

[INFO 2021-01-11 15:42:45,493 saml2.response get_subject 782: MainProcess] Subject NameID: <ns0:NameID xmlns:ns0=\"urn:oasis:names:tc:SAML:2.0:assertion\" Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">STSheldon@wellington.com</ns0:NameID>\n
[INFO 2021-01-11 15:42:45,495 saml2.client_base parse_authn_request_response 732: MainProcess] --- ADDED person info ----\n"
[INFO 2021-01-11 15:42:45,522 axes.watch_login log_user_logged_in 137: MainProcess] AXES: Successful login by {user: 'stsheldon@wellington.com', ip: '134.42.240.3', user-agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 Safari/537.36', path: '/api/saml2_auth/acs/'}.\n
```